### PR TITLE
Make up for a missing comma in the example response for v1_orders_detail

### DIFF
--- a/base_api_v1_orders_detail.md
+++ b/base_api_v1_orders_detail.md
@@ -20,7 +20,7 @@ read_orders
     "payment":"creditcard",
     "shipping_fee":500,
     "cod_fee":300,
-    "total":6800
+    "total":6800,
     "first_name":"山田",
     "last_name":"太郎",
     "country":"Japan",


### PR DESCRIPTION
`base_api_v1_orders_detail.md` の「レスポンスの例」の JSON 内のカンマが抜けており，
valid な JSON として parse できなかったので修正しました．